### PR TITLE
[WFLY-19102] Put the introduced channels element into the eap profile

### DIFF
--- a/images/pom.xml
+++ b/images/pom.xml
@@ -95,15 +95,6 @@
                         <configuration>
                             <!-- some tests check for the provisioned galleon layers -->
                             <record-provisioning-state>true</record-provisioning-state>
-                            <channels>
-                                <channel>
-                                    <manifest>
-                                        <groupId>${channel.manifest.groupid}</groupId>
-                                        <artifactId>${channel.manifest.artifactid}</artifactId>
-                                        <version>${channel.manifest.version}</version>
-                                    </manifest>
-                                </channel>
-                            </channels>
                             <feature-packs>
                                 <feature-pack>
                                     <location>${server.feature.pack.gav}</location>
@@ -201,6 +192,26 @@
                 <channel.manifest.artifactid>eap-8.0</channel.manifest.artifactid>
                 <channel.manifest.version>1.2.1.GA-redhat-00003</channel.manifest.version>
             </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>${server.maven.plugin.groupId}</groupId>
+                        <artifactId>${server.maven.plugin.artifactId}</artifactId>
+                        <version>${server.maven.plugin.version}</version>
+                        <configuration>
+                            <channels>
+                                <channel>
+                                    <manifest>
+                                        <groupId>${channel.manifest.groupid}</groupId>
+                                        <artifactId>${channel.manifest.artifactid}</artifactId>
+                                        <version>${channel.manifest.version}</version>
+                                    </manifest>
+                                </channel>
+                            </channels>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>xp</id>


### PR DESCRIPTION
If I do this it looks like WildFly stays the way it was, and EAP has the channels.


```
$ mvn help:effective-pom
-- SNIP --
 <profile>
        <id>images</id>
        <build>
          <plugins>
            <plugin>
              <groupId>org.wildfly.plugins</groupId>
              <artifactId>wildfly-maven-plugin</artifactId>
              <version>5.0.1.Final</version>
              <executions>
                <execution>
                  <id>provision-base-cloud-server</id>
                  <phase>process-test-resources</phase>
                  <goals>
                    <goal>package</goal>
                  </goals>
                </execution>
              </executions>
              <configuration>
                <record-provisioning-state>true</record-provisioning-state>
                <feature-packs>
                  <feature-pack>
                    <location>org.wildfly:wildfly-galleon-pack:33.0.0.Final</location>
                  </feature-pack>
                  <feature-pack>
                    <location>org.wildfly.cloud:wildfly-cloud-galleon-pack:6.0.0.Final</location>
                  </feature-pack>
                </feature-packs>
                <skip>true</skip>
                <galleon-options>
                  <jboss-fork-embedded>${plugin.fork.embedded}</jboss-fork-embedded>
                </galleon-options>
              </configuration>
            </plugin>
-- SNIP --
```
vs
```
 mvn help:effective-pom -Pimages,eap -pl images
-- SNIP --
<plugin>
        <groupId>org.jboss.eap.plugins</groupId>
        <artifactId>eap-maven-plugin</artifactId>
        <version>1.0.1.Final-redhat-00008</version>
        <executions>
          <execution>
            <id>provision-base-cloud-server</id>
            <phase>process-test-resources</phase>
            <goals>
              <goal>package</goal>
            </goals>
            <configuration>
              <channels>
                <channel>
                  <manifest>
                    <groupId>org.jboss.eap.channels</groupId>
                    <artifactId>eap-8.0</artifactId>
                    <version>1.2.1.GA-redhat-00003</version>
                  </manifest>
                </channel>
              </channels>
              <record-provisioning-state>true</record-provisioning-state>
              <feature-packs>
                <feature-pack>
                  <location>org.jboss.eap:wildfly-ee-galleon-pack:8.0.0.GA-redhat-00011</location>
                </feature-pack>
                <feature-pack>
                  <location>org.jboss.eap.cloud:eap-cloud-galleon-pack:1.0.0.Final-redhat-00008</location>
                </feature-pack>
              </feature-packs>
              <skip>true</skip>
              <galleon-options>
                <jboss-fork-embedded>${plugin.fork.embedded}</jboss-fork-embedded>
              </galleon-options>
            </configuration>
          </execution>

-- SNIP -- 
```